### PR TITLE
improve data processing performance

### DIFF
--- a/ERICAModelTraining.py
+++ b/ERICAModelTraining.py
@@ -28,7 +28,7 @@ from tensorflow.python.keras.layers import Conv2D
 import time
 import random
 
-TOKEN = {'G': 0, 'T': 1, 'A': 2, 'C': 3, 'N': 4, '-': 5, 'g': 0, 't': 1, 'a': 2, 'c': 3, 'n': 4}
+TOKEN = str.maketrans("GTACN-gtacn","\0\1\2\3\4\5\0\1\2\3\4")
 ###############################################################################
 # function part
 ###############################################################################
@@ -62,13 +62,9 @@ def FiveTaxonCalculateDiff(datas):
 
 def FourTaxonDataProcess(src_path):
     print('%s\t%s\tData Preprocessing > > > > > > > > > > \n' % ((time.asctime(time.localtime(time.time()))), src_path))
-    lines = open(src_path, 'r').readlines()
-    def FnToken(x):
-        for key in TOKEN:
-            x = x.replace(key, str(TOKEN[key]))
-        return x
-    lines = [FnToken(x.strip()) for x in lines]
-    lines = np.array([list(x) for x in lines], dtype=np.uint8)
+    with open(src_path, 'r') as f:
+        lines = [l.strip().translate(TOKEN).encode("ascii") for l in f]
+    lines = np.stack([np.frombuffer(l, dtype=np.uint8) for l in lines])
     print('Shape of MSA:', lines.shape)
     data_len = lines.shape[1]
     result = data_len%5000
@@ -84,13 +80,9 @@ def FourTaxonDataProcess(src_path):
 
 def FiveTaxonDataProcess(src_path):
     print('%s\t%s\tData Preprocessing > > > > > > > > > > \n' % ((time.asctime(time.localtime(time.time()))), src_path))
-    lines = open(src_path, 'r').readlines()
-    def FnToken(x):
-        for key in TOKEN:
-            x = x.replace(key, str(TOKEN[key]))
-        return x
-    lines = [FnToken(x.strip()) for x in lines]
-    lines = np.array([list(x) for x in lines], dtype=np.uint8)
+    with open(src_path, 'r') as f:
+        lines = [l.strip().translate(TOKEN).encode("ascii") for l in f]
+    lines = np.stack([np.frombuffer(l, dtype=np.uint8) for l in lines])
     print('Shape of MSA:', lines.shape)
     data_len = lines.shape[1]
     result = data_len%5000

--- a/ERICAPrediction.py
+++ b/ERICAPrediction.py
@@ -28,7 +28,7 @@ from tensorflow.python.keras.layers import Conv2D
 import time
 
 
-TOKEN = {'G': 0, 'T': 1, 'A': 2, 'C': 3, 'N': 4, '-': 5, 'g': 0, 't': 1, 'a': 2, 'c': 3, 'n': 4}
+TOKEN = str.maketrans("GTACN-gtacn","\0\1\2\3\4\5\0\1\2\3\4")
 ###############################################################################
 # function part
 ###############################################################################
@@ -62,13 +62,9 @@ def FiveTaxonCalculateDiff(datas):
 
 def FourTaxonDataProcess(src_path):
     print('%s\t%s\tData Preprocessing > > > > > > > > > > \n' % ((time.asctime(time.localtime(time.time()))), src_path))
-    lines = open(src_path, 'r').readlines()
-    def FnToken(x):
-        for key in TOKEN:
-            x = x.replace(key, str(TOKEN[key]))
-        return x
-    lines = [FnToken(x.strip()) for x in lines]
-    lines = np.array([list(x) for x in lines], dtype=np.uint8)
+    with open(src_path, 'r') as f:
+        lines = [l.strip().translate(TOKEN).encode("ascii") for l in f]
+    lines = np.stack([np.frombuffer(l, dtype=np.uint8) for l in lines])
     print('Shape of MSA:', lines.shape)
     data_len = lines.shape[1]
     result = data_len%5000
@@ -84,13 +80,9 @@ def FourTaxonDataProcess(src_path):
 
 def FiveTaxonDataProcess(src_path):
     print('%s\t%s\tData Preprocessing > > > > > > > > > > \n' % ((time.asctime(time.localtime(time.time()))), src_path))
-    lines = open(src_path, 'r').readlines()
-    def FnToken(x):
-        for key in TOKEN:
-            x = x.replace(key, str(TOKEN[key]))
-        return x
-    lines = [FnToken(x.strip()) for x in lines]
-    lines = np.array([list(x) for x in lines], dtype=np.uint8)
+    with open(src_path, 'r') as f:
+        lines = [l.strip().translate(TOKEN).encode("ascii") for l in f]
+    lines = np.stack([np.frombuffer(l, dtype=np.uint8) for l in lines])
     print('Shape of MSA:', lines.shape)
     data_len = lines.shape[1]
     result = data_len%5000


### PR DESCRIPTION
This pull request aims to optimize data reading performance.

The new code is more than 10x faster than the original one.

<details open>
<summary>benchmarking</summary>

```python
import numpy as np

def ReadMSA_new(src_path):
    TOKEN = str.maketrans("GTACN-gtacn","\0\1\2\3\4\5\0\1\2\3\4")
    with open(src_path, 'r') as f:
        lines = [l.strip().translate(TOKEN).encode("ascii") for l in f]
    lines = np.stack([np.frombuffer(l, dtype=np.uint8) for l in lines])
    return lines

def ReadMSA_old(src_path):
    TOKEN = {'G': 0, 'T': 1, 'A': 2, 'C': 3, 'N': 4, '-': 5, 'g': 0, 't': 1, 'a': 2, 'c': 3, 'n': 4}
    lines = open(src_path, 'r').readlines()
    def FnToken(x):
        for key in TOKEN:
            x = x.replace(key, str(TOKEN[key]))
        return x
    lines = [FnToken(x.strip()) for x in lines]
    lines = np.array([list(x) for x in lines], dtype=np.uint8)
    return lines
```

result:

```
>>> import timeit
>>> timeit.timeit(lambda:ReadMSA_new("test/pop_test_Hmel218003o.txt"),number=10)
0.5833460371941328
>>> timeit.timeit(lambda:ReadMSA_old("test/pop_test_Hmel218003o.txt"),number=10)
32.958660209551454
>>> np.all(ReadMSA_new("test/pop_test_Hmel218003o.txt")==ReadMSA_old("test/pop_test_Hmel218003o.txt"))
True
```
</details>